### PR TITLE
Send at most 1000 messages per buffer cycle

### DIFF
--- a/src/kinesis/producer.py
+++ b/src/kinesis/producer.py
@@ -53,12 +53,6 @@ class AsyncProducer(SubprocessLoop):
                 'PartitionKey': '{0}{1}'.format(time.clock(), time.time()),
             }
 
-            records_count += 1
-            if records_count == self.MAX_COUNT:
-                log.debug("Records exceed MAX_COUNT!  Adding to next_records: %s", record)
-                self.next_records = [record]
-                break
-
             records_size += sys.getsizeof(record)
             if records_size >= self.MAX_SIZE:
                 log.debug("Records exceed MAX_SIZE!  Adding to next_records: %s", record)
@@ -67,6 +61,11 @@ class AsyncProducer(SubprocessLoop):
 
             log.debug("Adding to records (%d bytes): %s", records_size, record)
             self.records.append(record)
+
+            records_count += 1
+            if records_count == self.MAX_COUNT:
+                log.debug("Records have reached MAX_COUNT!  Flushing records.")
+                break
 
         self.flush_records()
 

--- a/src/kinesis/producer.py
+++ b/src/kinesis/producer.py
@@ -55,7 +55,7 @@ class AsyncProducer(SubprocessLoop):
             }
 
             records_count += 1
-            if records_count >= self.MAX_COUNT:
+            if records_count == self.MAX_COUNT:
                 log.debug("Records exceed MAX_COUNT!  Adding to next_records: %s", record)
                 self.next_records = [record]
                 break

--- a/src/kinesis/producer.py
+++ b/src/kinesis/producer.py
@@ -23,7 +23,6 @@ class AsyncProducer(SubprocessLoop):
     # This is the max number of messages that we'll send in a single call.
     MAX_COUNT = 1000
 
-
     def __init__(self, stream_name, buffer_time, queue, boto3_session=None):
         self.stream_name = stream_name
         self.buffer_time = buffer_time

--- a/src/kinesis/producer.py
+++ b/src/kinesis/producer.py
@@ -43,8 +43,12 @@ class AsyncProducer(SubprocessLoop):
         timer_start = time.time()
 
         while self.alive and (time.time() - timer_start) < self.buffer_time:
+            # we want our queue to block up until the end of this buffer cycle, so we set out timeout to the amount
+            # remaining in buffer_time by substracting how long we spent so far during this cycle
+            queue_timeout = self.buffer_time - (time.time() - timer_start)
             try:
-                data = self.queue.get(block=True, timeout=0.25)
+                log.debug("Fetching from queue with timeout: %s", queue_timeout)
+                data = self.queue.get(block=True, timeout=queue_timeout)
             except Queue.Empty:
                 continue
 


### PR DESCRIPTION
In #3 @itamarla correctly pointed out that we do not honor the limit of 1000 messages per second from the kinesis limits:  http://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html

This PR adds another counter to the producer loop that breaks out if we exceed 1000 messages per buffer cycle.

See my comment -- https://github.com/NerdWalletOSS/kinesis-python/issues/3#issuecomment-317952158 -- where I discuss the full scope of the REAL issue at hand, as this producer loop will likely need to be changed fairly significantly correctly conform to/leverage the service limits.

----

This PR also changes the semantics of how we spend our time each buffer cycle so that we block on `queue.get` for as much time as possible, rather than looping needlessly. (f1f8c4f)