### PR TITLE
Update MAX_COUNT to be the maximum number of allowed by PutRecords

### DIFF
--- a/src/kinesis/producer.py
+++ b/src/kinesis/producer.py
@@ -60,7 +60,7 @@ class AsyncProducer(SubprocessLoop):
     #   per second (including partition keys).
     # * PutRecords supports up to 500 records in a single call
     MAX_SIZE = (2 ** 20)
-    MAX_COUNT = 500 
+    MAX_COUNT = 500
 
     def __init__(self, stream_name, buffer_time, queue, max_count=None, max_size=None, boto3_session=None):
         self.stream_name = stream_name

--- a/src/kinesis/producer.py
+++ b/src/kinesis/producer.py
@@ -58,8 +58,9 @@ class AsyncProducer(SubprocessLoop):
     # * The maximum size of a data blob (the data payload before base64-encoding) is up to 1 MB.
     # * Each shard can support up to 1,000 records per second for writes, up to a maximum total data write rate of 1 MB
     #   per second (including partition keys).
+    # * PutRecords supports up to 500 records in a single call
     MAX_SIZE = (2 ** 20)
-    MAX_COUNT = 1000
+    MAX_COUNT = 500 
 
     def __init__(self, stream_name, buffer_time, queue, max_count=None, max_size=None, boto3_session=None):
         self.stream_name = stream_name


### PR DESCRIPTION

According to AWS documentation[1], when putting multiple records in a single call
the maximum number of records are 500 for a single call. The previous count was based
off of the max rate that kinesis shard can handle

[1] https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html