### PR TITLE
Add support to "AT_TIMESTAMP" ShardIteratorType

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ botocore==1.8.9           # via boto3, s3transfer
 docutils==0.14            # via botocore
 jmespath==0.9.3           # via boto3, botocore
 offspring==0.0.3
-python-dateutil==2.6.1    # via botocore
+python-dateutil==2.6.1
 s3transfer==0.1.12        # via boto3
 six==1.11.0               # via python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     url='https://github.com/NerdWalletOSS/kinesis-python',
 
     install_requires=[
+        'python-dateutil',
         'boto3>=1.4.4,<2.0',
         'offspring>=0.0.3,<1.0',
         'six>=1.11.0,<2.0',

--- a/src/kinesis/consumer.py
+++ b/src/kinesis/consumer.py
@@ -139,8 +139,8 @@ class KinesisConsumer(object):
                     # no self.state
                     if self.start_at_timestamp is not None:
                         iterator_args = {
-                            "ShardIteratorType"='AT_TIMESTAMP',
-                            "Timestamp"=dateutil.parser.parse(
+                            "ShardIteratorType": 'AT_TIMESTAMP',
+                            "Timestamp": dateutil.parser.parse(
                                 self.start_at_timestamp
                             )
                         }   

--- a/src/kinesis/consumer.py
+++ b/src/kinesis/consumer.py
@@ -4,6 +4,7 @@ import logging
 import multiprocessing
 import time
 
+import dateutil.parser
 import boto3
 import six.moves.queue
 from botocore.exceptions import ClientError

--- a/src/kinesis/consumer.py
+++ b/src/kinesis/consumer.py
@@ -80,7 +80,7 @@ class KinesisConsumer(object):
     """
     LOCK_DURATION = 30
 
-    def __init__(self, stream_name, boto3_session=None, state=None, reader_sleep_time=None):
+    def __init__(self, stream_name, boto3_session=None, state=None, reader_sleep_time=None, start_at_timestamp=None):
         self.stream_name = stream_name
         self.error_queue = multiprocessing.Queue()
         self.record_queue = multiprocessing.Queue()
@@ -91,7 +91,8 @@ class KinesisConsumer(object):
         self.state = state
 
         self.reader_sleep_time = reader_sleep_time
-
+        self.start_at_timestamp = start_at_timestamp
+        
         self.shards = {}
         self.stream_data = None
         self.run = True
@@ -136,7 +137,15 @@ class KinesisConsumer(object):
                     iterator_args = self.state.get_iterator_args(self.state_shard_id(shard_data['ShardId']))
                 except AttributeError:
                     # no self.state
-                    iterator_args = dict(ShardIteratorType='LATEST')
+                    if self.start_at_timestamp is not None:
+                        iterator_args = {
+                            "ShardIteratorType"='AT_TIMESTAMP',
+                            "Timestamp"=dateutil.parser.parse(
+                                self.start_at_timestamp
+                            )
+                        }   
+                    else:
+                        iterator_args = dict(ShardIteratorType='LATEST')
 
                 log.info("%s iterator arguments: %s", shard_data['ShardId'], iterator_args)
 


### PR DESCRIPTION
As documented here:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kinesis.html#Kinesis.Client.get_shard_iterator

I think those lines may be enough to support AT_TIMESTAMP behavior.
It is not tested yet.

It should be used this way:
```python3
    from kinesis.consumer import KinesisConsumer

    consumer = KinesisConsumer(stream_name='my-stream', start_at_timestamp='20190901')
    for message in consumer:
        print "Received message: {0}".format(message)
```
Regards,
M0dM